### PR TITLE
Grant wheel group to sudo (in a separated file)

### DIFF
--- a/README.org
+++ b/README.org
@@ -60,7 +60,7 @@ pacman -S sudo
 #+end_src
 *** 8. Grant sudo
 #+begin_src sh
-echo "myusername ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+echo "%wheel ALL=(ALL) ALL" > /etc/sudoers.d/10-grant-wheel-group
 #+end_src
 *** 9. Set up locale
 #+begin_src sh


### PR DESCRIPTION
It's maybe a better practice to add custom `sudo` settings in a separated file in `/etc/sudoers.d` and what about grating it for the whole `wheel` group?