### PR TITLE
Typo in Locale.conf (UTF-8, not UTF8)

### DIFF
--- a/README.org
+++ b/README.org
@@ -79,7 +79,7 @@ nano /etc/locale.gen
 #+end_src
 #+begin_src sh
 locale-gen
-echo LANG=en_US.UTF8 > /etc/locale.conf
+echo LANG=en_US.UTF-8 > /etc/locale.conf
 export LANG=en_US.UTF-8
 #+end_src
 *** 10. Set up mkinitcpio hooks and run

--- a/README.org
+++ b/README.org
@@ -143,7 +143,7 @@ touch SystemVersion.plist
 nano SystemVersion.plist
 #+end_src
 #+begin_example
-<xml version="1.0" encoding="utf-8"?>
+<xml version="1.0" encoding="utf-8"/>
 <plist version="1.0">
 <dict>
     <key>ProductBuildVersion</key>

--- a/README.org
+++ b/README.org
@@ -143,7 +143,7 @@ touch SystemVersion.plist
 nano SystemVersion.plist
 #+end_src
 #+begin_example
-<xml version="1.0" encoding="utf-8"/>
+<xml version="1.0" encoding="utf-8"?>
 <plist version="1.0">
 <dict>
     <key>ProductBuildVersion</key>


### PR DESCRIPTION
just wanted to fix this typo
